### PR TITLE
Really add compatibility with laravel after 5.7 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,15 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "illuminate/database": "^5.0|^6.0|^7.0",
-        "illuminate/http": "^5.0|^6.0|^7.0",
-        "illuminate/support": "^5.0|^6.0|^7.0"
+        "php": ">=7.2.5",
+        "illuminate/database": "^5.7|^6.0|^7.0",
+        "illuminate/http": "^5.7|^6.0|^7.0",
+        "illuminate/support": "^5.7|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.1",
-        "orchestra/testbench": "~3.5"
+        "phpunit/phpunit": "^7.5",
+        "orchestra/testbench": "^3.7",
+        "mockery/mockery": "^1.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Builders/CollectionVuetableBuilder.php
+++ b/src/Builders/CollectionVuetableBuilder.php
@@ -96,13 +96,13 @@ class CollectionVuetableBuilder extends BaseBuilder
 
             $this->collection = $this->collection
                 ->map(function ($data) {
-                    return array_dot($data);
+                    return Arr::dot($data);
                 })
                 ->sort($comparer)
                 ->map(function ($data) {
                     foreach ($data as $key => $value) {
                         unset($data[$key]);
-                        array_set($data, $key, $value);
+                        Arr::set($data, $key, $value);
                     }
 
                     return $data;
@@ -185,7 +185,7 @@ class CollectionVuetableBuilder extends BaseBuilder
     public function addItem($item)
     {
         foreach ($this->columnsToAdd as $column => $value) {
-            if (array_has($item, $column)) {
+            if (Arr::has($item, $column)) {
                 throw new \Exception("Can not add the '{$column}' column, the results already have that column.");
             }
 
@@ -199,7 +199,7 @@ class CollectionVuetableBuilder extends BaseBuilder
     public function editItem($item)
     {
         foreach ($this->columnsToEdit as $column => $value) {
-            if (array_has($item, $column) === false) {
+            if (Arr::has($item, $column) === false) {
                 throw new \Exception("Column {$column} not exist in array");
             }
 


### PR DESCRIPTION
We have two possibilities:

The ideal: 
``` 
"illuminate/database": "^5.7|^6.0|^7.0",
"illuminate/http": "^5.7|^6.0|^7.0",
 "illuminate/support": "^5.7|^6.0|^7.0"
``` 
The real to not breaking changes before laravel 5.7:
``` 
"illuminate/database": "^5.0|^5.6",
"illuminate/http": "^5.0|^5.6",
"illuminate/support": "^5.0|^6.6" 
```
This is becouse laravel remove array helpers after 5.6