### PR TITLE
Order direction can also be specified with a separate "order" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Your request to the controller should have this data:
 }
 ```
 
+You can also specify the sorting order using the "order" attribute (required by https://mannyyang.github.io/vuetable-3/ ):
+```javascript
+{
+    sort: '', // column_name
+    order: '', // asc or desc
+}
+```
+
+
 So for example lets create the table for the users with their companies. Then in the javascript we should have:
 
 ```javascript

--- a/src/Builders/CollectionVuetableBuilder.php
+++ b/src/Builders/CollectionVuetableBuilder.php
@@ -83,7 +83,7 @@ class CollectionVuetableBuilder extends BaseBuilder
             : $this->request->input('order', 'desc');
 
         if ($field) {
-            $comparer = function ($a, $b) use ($field,$direction) {
+            $comparer = function ($a, $b) use ($field, $direction) {
                 if ($direction === 'desc') {
                     $first = $b;
                     $second = $a;

--- a/src/Builders/CollectionVuetableBuilder.php
+++ b/src/Builders/CollectionVuetableBuilder.php
@@ -74,7 +74,13 @@ class CollectionVuetableBuilder extends BaseBuilder
             return $this;
         }
 
-        list($field, $direction) = explode('|', $this->request->input('sort'));
+        $sort_parts = explode('|', $this->request->input('sort'));
+
+        $field = $sort_parts[0];
+
+        $direction = count($sort_parts) > 1
+            ? $sort_parts[1]
+            : $this->request->input('order', 'desc');
 
         if ($field) {
             $comparer = function ($a, $b) use ($field,$direction) {

--- a/src/Builders/EloquentVuetableBuilder.php
+++ b/src/Builders/EloquentVuetableBuilder.php
@@ -59,9 +59,15 @@ class EloquentVuetableBuilder extends BaseBuilder
         if (!$this->request->input('sort')) {
             return $this;
         }
+        
+        $sort_parts = explode('|', $this->request->input('sort'));
 
-        list($field, $direction) = explode('|', $this->request->input('sort'));
+        $field = $sort_parts[0];
 
+        $direction = count($sort_parts) > 1
+            ? $sort_parts[1]
+            : $this->request->input('order', 'desc');
+        
         $this->query->orderBy($field, $direction);
 
         return $this;


### PR DESCRIPTION
Order direction can be specified both in the sort attribute (with the "field | direction" format) or in a separate attribute called "order".

This make this package compatible with https://mannyyang.github.io/vuetable-3